### PR TITLE
Add face up card styling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@
 ## Type of Change
 
 - [ ] Bug fix
+- [ ] Enhancement
 - [ ] New feature
 - [ ] Chore: update dependencies or other housekeeping
 - [ ] Documentation update

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.4] - 2026-04-20
+
+### Changed
+
+- Updated face-up card styling to add a clearer border so revealed cards stand out from the board background.
+- Removed disabled-state opacity from cards so face-down card shading stays consistent while match checks are resolving.
+
 ## [0.0.3] - 2026-04-17
 
 ### Added

--- a/src/components/EmojiCard.tsx
+++ b/src/components/EmojiCard.tsx
@@ -29,7 +29,7 @@ export default function EmojiCard({
         "emoji-card relative w-full aspect-square rounded-xl transition-transform duration-200",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-500/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
         cardStateClass,
-        disabled ? "cursor-not-allowed opacity-80" : "hover:scale-[1.03] active:scale-[0.98]",
+        disabled ? "cursor-not-allowed" : "hover:scale-[1.03] active:scale-[0.98]",
       ].join(" ")}
     >
       <span className="card-flip-inner">

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,10 @@
     background: rgb(255 255 255 / 0.9);
   }
 
+  .emoji-card.is-face-up .card-front {
+    border-color: rgb(74 222 128 / 0.8);
+  }
+
   .emoji-card.is-matched .card-front {
     border-color: rgb(74 222 128 / 0.8);
     background: rgb(74 222 128 / 0.1);


### PR DESCRIPTION
# Description

<!-- Provide a brief overview of the changes in this pull request. -->

This PR improves card visual feedback during gameplay so card states are clearer and more consistent. Face-up cards now have a more prominent border, and face-down cards no longer appear lighter while the board is temporarily locked during match evaluation.

This PR also modifies this PR template by adding a new change type: enhancement.

No new tests were added because this is a presentational UI styling update with no game logic changes.

No documentation changes were needed because user-facing behavior and setup instructions remain the same.

## Related Issues

<!-- Link to related issues or tasks here (e.g., Fixes #123, Related to #456). -->

Fixes #4 

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

## Screenshots (if applicable)

<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

**Before change:**

<img width="417" height="392" alt="Screenshot on 2026-04-20 at 11-06-06" src="https://github.com/user-attachments/assets/7133939c-7f5b-4011-aa0c-85ab753b8b95" />

**After change:** 

<img width="408" height="398" alt="Screenshot on 2026-04-20 at 11-06-32" src="https://github.com/user-attachments/assets/a77fbb48-0c53-4e68-8915-8b6635a17f0d" />
