### PR TITLE
Add footer and info modal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.6] - 2026-04-22
+
+### Added
+
+- Added a new app footer with a dynamic year copyright notice and a centered GitHub repo link with accessible metadata.
+- Added legal/info modal support for `Credits`, `Terms of Use`, and `Privacy Policy` via new `Footer` and reusable `InfoModal` components.
+- Added dedicated unit test suites for `Footer` and `InfoModal`, plus an app-level assertion that footer content renders with the game UI.
+
+### Changed
+
+- Updated the credits modal placeholder text to include attribution for Pixabay sound effects.
+- Refined footer layout so copyright, centered GitHub icon, and legal links align cleanly across screen sizes.
+
 ## [0.0.5] - 2026-04-20
 
 ### Added

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -53,6 +53,14 @@ describe("App", () => {
     expect(screen.getByText(/Flip two cards to find matching emojis/)).toBeInTheDocument();
   });
 
+  it("renders footer content with legal links", () => {
+    render(<App />);
+    expect(screen.getByText(/Copyright \d{4} Emoji Match Game\./)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Credits" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Terms of Use" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Privacy Policy" })).toBeInTheDocument();
+  });
+
   it("after a matching pair, increments matches only after MATCH_DELAY_MS", () => {
     render(<App />);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useReducer, useRef } from "react";
 import { playSfx } from "./audio/sfx";
 import Board from "./components/Board";
+import Footer from "./components/Footer";
 import { createGame, gameReducer, MATCH_DELAY_MS, MISMATCH_DELAY_MS } from "./game/game";
 import type { CardId } from "./game/types";
 
@@ -71,6 +72,8 @@ function App() {
         onCardClick={onCardClick}
         onReset={onReset}
       />
+
+      <Footer />
     </div>
   );
 }

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Footer from "./Footer";
+
+describe("Footer", () => {
+  it("shows copyright notice with current year", () => {
+    render(<Footer />);
+    const year = new Date().getFullYear();
+    expect(screen.getByText(`Copyright ${year} Emoji Match Game.`)).toBeInTheDocument();
+  });
+
+  it("renders Github link with required title and placeholder URL", () => {
+    render(<Footer />);
+    const githubLink = screen.getByRole("link", { name: "View source on Github" });
+
+    expect(githubLink).toHaveAttribute(
+      "title",
+      "This project is open source. View the code on Github.",
+    );
+    expect(githubLink).toHaveAttribute("href", "https://github.com/example/emoji-match-game");
+  });
+
+  it("renders all legal links", () => {
+    render(<Footer />);
+    expect(screen.getByRole("button", { name: "Credits" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Terms of Use" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Privacy Policy" })).toBeInTheDocument();
+  });
+
+  it("opens the matching modal for each legal link", async () => {
+    const user = userEvent.setup();
+    render(<Footer />);
+
+    await user.click(screen.getByRole("button", { name: "Credits" }));
+    expect(screen.getByRole("dialog", { name: "Credits" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Close modal" }));
+
+    await user.click(screen.getByRole("button", { name: "Terms of Use" }));
+    expect(screen.getByRole("dialog", { name: "Terms of Use" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Close modal" }));
+
+    await user.click(screen.getByRole("button", { name: "Privacy Policy" }));
+    expect(screen.getByRole("dialog", { name: "Privacy Policy" })).toBeInTheDocument();
+  });
+});

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,12 +3,12 @@ import InfoModal from "./InfoModal";
 
 type ModalKey = "credits" | "terms" | "privacy";
 
-const GITHUB_REPO_URL = "https://github.com/example/emoji-match-game";
+const GITHUB_REPO_URL = "https://github.com/allie500/emoji-match-game";
 
 const MODAL_CONTENT: Record<ModalKey, { title: string; body: string }> = {
   credits: {
     title: "Credits",
-    body: "Emoji Match Game is built with React, TypeScript, and open source tools.",
+    body: "Emoji Match Game is built with React, TypeScript, and open source tools. Sound effects downloaded from Pixabay.",
   },
   terms: {
     title: "Terms of Use",
@@ -27,26 +27,26 @@ export default function Footer() {
   return (
     <>
       <footer className="mt-8 w-full max-w-2xl border-t border-slate-700 pt-4">
-        <div className="flex flex-col items-center gap-3 text-center text-sm text-slate-400 sm:flex-row sm:justify-between sm:text-left">
-          <p>Copyright {year} Emoji Match Game.</p>
-          <div className="flex items-center gap-3">
-            <a
-              href={GITHUB_REPO_URL}
-              target="_blank"
-              rel="noreferrer"
-              title="This project is open source. View the code on Github."
-              aria-label="View source on Github"
-              className="rounded-md p-1 text-slate-300 hover:bg-slate-800 hover:text-white"
+        <div className="grid gap-3 text-center text-sm text-slate-400 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+          <p className="sm:text-left">Copyright {year} Emoji Match Game.</p>
+          <a
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            rel="noreferrer"
+            title="This project is open source. View the code on Github."
+            aria-label="View source on Github"
+            className="mx-auto rounded-md p-1 text-slate-300 hover:bg-slate-800 hover:text-white"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+              className="h-5 w-5 fill-current"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-                className="h-5 w-5 fill-current"
-              >
-                <path d="M12 0a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.26c-3.34.73-4.04-1.42-4.04-1.42a3.2 3.2 0 0 0-1.33-1.77c-1.09-.74.08-.72.08-.72a2.52 2.52 0 0 1 1.84 1.23 2.58 2.58 0 0 0 3.53 1 2.58 2.58 0 0 1 .77-1.63c-2.67-.31-5.47-1.35-5.47-6a4.7 4.7 0 0 1 1.24-3.24 4.37 4.37 0 0 1 .12-3.19s1-.33 3.3 1.24a11.37 11.37 0 0 1 6 0c2.28-1.57 3.3-1.24 3.3-1.24a4.37 4.37 0 0 1 .12 3.19 4.69 4.69 0 0 1 1.24 3.24c0 4.66-2.8 5.68-5.48 6a2.88 2.88 0 0 1 .82 2.24v3.32c0 .32.22.69.83.58A12 12 0 0 0 12 0Z" />
-              </svg>
-            </a>
+              <path d="M12 0a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.26c-3.34.73-4.04-1.42-4.04-1.42a3.2 3.2 0 0 0-1.33-1.77c-1.09-.74.08-.72.08-.72a2.52 2.52 0 0 1 1.84 1.23 2.58 2.58 0 0 0 3.53 1 2.58 2.58 0 0 1 .77-1.63c-2.67-.31-5.47-1.35-5.47-6a4.7 4.7 0 0 1 1.24-3.24 4.37 4.37 0 0 1 .12-3.19s1-.33 3.3 1.24a11.37 11.37 0 0 1 6 0c2.28-1.57 3.3-1.24 3.3-1.24a4.37 4.37 0 0 1 .12 3.19 4.69 4.69 0 0 1 1.24 3.24c0 4.66-2.8 5.68-5.48 6a2.88 2.88 0 0 1 .82 2.24v3.32c0 .32.22.69.83.58A12 12 0 0 0 12 0Z" />
+            </svg>
+          </a>
+          <div className="flex items-center justify-center gap-3 sm:justify-end">
             <button
               type="button"
               className="hover:text-slate-200"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,83 @@
+import { useMemo, useState } from "react";
+import InfoModal from "./InfoModal";
+
+type ModalKey = "credits" | "terms" | "privacy";
+
+const GITHUB_REPO_URL = "https://github.com/example/emoji-match-game";
+
+const MODAL_CONTENT: Record<ModalKey, { title: string; body: string }> = {
+  credits: {
+    title: "Credits",
+    body: "Emoji Match Game is built with React, TypeScript, and open source tools.",
+  },
+  terms: {
+    title: "Terms of Use",
+    body: "This game is provided as-is for personal and educational use.",
+  },
+  privacy: {
+    title: "Privacy Policy",
+    body: "This app does not collect personal data and runs entirely in your browser.",
+  },
+};
+
+export default function Footer() {
+  const year = useMemo(() => new Date().getFullYear(), []);
+  const [activeModal, setActiveModal] = useState<ModalKey | null>(null);
+
+  return (
+    <>
+      <footer className="mt-8 w-full max-w-2xl border-t border-slate-700 pt-4">
+        <div className="flex flex-col items-center gap-3 text-center text-sm text-slate-400 sm:flex-row sm:justify-between sm:text-left">
+          <p>Copyright {year} Emoji Match Game.</p>
+          <div className="flex items-center gap-3">
+            <a
+              href={GITHUB_REPO_URL}
+              target="_blank"
+              rel="noreferrer"
+              title="This project is open source. View the code on Github."
+              aria-label="View source on Github"
+              className="rounded-md p-1 text-slate-300 hover:bg-slate-800 hover:text-white"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                className="h-5 w-5 fill-current"
+              >
+                <path d="M12 0a12 12 0 0 0-3.79 23.39c.6.11.82-.26.82-.58v-2.26c-3.34.73-4.04-1.42-4.04-1.42a3.2 3.2 0 0 0-1.33-1.77c-1.09-.74.08-.72.08-.72a2.52 2.52 0 0 1 1.84 1.23 2.58 2.58 0 0 0 3.53 1 2.58 2.58 0 0 1 .77-1.63c-2.67-.31-5.47-1.35-5.47-6a4.7 4.7 0 0 1 1.24-3.24 4.37 4.37 0 0 1 .12-3.19s1-.33 3.3 1.24a11.37 11.37 0 0 1 6 0c2.28-1.57 3.3-1.24 3.3-1.24a4.37 4.37 0 0 1 .12 3.19 4.69 4.69 0 0 1 1.24 3.24c0 4.66-2.8 5.68-5.48 6a2.88 2.88 0 0 1 .82 2.24v3.32c0 .32.22.69.83.58A12 12 0 0 0 12 0Z" />
+              </svg>
+            </a>
+            <button
+              type="button"
+              className="hover:text-slate-200"
+              onClick={() => setActiveModal("credits")}
+            >
+              Credits
+            </button>
+            <button
+              type="button"
+              className="hover:text-slate-200"
+              onClick={() => setActiveModal("terms")}
+            >
+              Terms of Use
+            </button>
+            <button
+              type="button"
+              className="hover:text-slate-200"
+              onClick={() => setActiveModal("privacy")}
+            >
+              Privacy Policy
+            </button>
+          </div>
+        </div>
+      </footer>
+
+      <InfoModal
+        title={activeModal ? MODAL_CONTENT[activeModal].title : ""}
+        body={activeModal ? MODAL_CONTENT[activeModal].body : ""}
+        isOpen={activeModal !== null}
+        onClose={() => setActiveModal(null)}
+      />
+    </>
+  );
+}

--- a/src/components/InfoModal.test.tsx
+++ b/src/components/InfoModal.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import InfoModal from "./InfoModal";
+
+describe("InfoModal", () => {
+  it("renders dialog content when open", () => {
+    render(<InfoModal title="Credits" body="Some credits text" isOpen={true} onClose={vi.fn()} />);
+
+    expect(screen.getByRole("dialog", { name: "Credits" })).toBeInTheDocument();
+    expect(screen.getByText("Some credits text")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close modal" })).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    render(<InfoModal title="Credits" body="Some credits text" isOpen={false} onClose={vi.fn()} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when pressing Escape", () => {
+    const onClose = vi.fn();
+    render(<InfoModal title="Credits" body="Some credits text" isOpen={true} onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when pressing other keys", () => {
+    const onClose = vi.fn();
+    render(<InfoModal title="Credits" body="Some credits text" isOpen={true} onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: "Enter" });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("calls onClose when clicking overlay", () => {
+    const onClose = vi.fn();
+    render(<InfoModal title="Credits" body="Some credits text" isOpen={true} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("info-modal-overlay"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when clicking inside the panel", () => {
+    const onClose = vi.fn();
+    render(<InfoModal title="Credits" body="Some credits text" isOpen={true} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("dialog", { name: "Credits" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+export interface InfoModalProps {
+  title: string;
+  body: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function InfoModal({ title, body, isOpen, onClose }: InfoModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4"
+      onClick={onClose}
+      data-testid="info-modal-overlay"
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="w-full max-w-md rounded-xl border border-slate-700 bg-slate-900 p-5 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <h2 className="text-lg font-semibold text-slate-100">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm text-slate-300 hover:bg-slate-800 hover:text-white"
+            aria-label="Close modal"
+          >
+            Close
+          </button>
+        </div>
+        <p className="mt-3 text-sm leading-6 text-slate-300">{body}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Description

Adds a new footer experience to the app with legal/info modal support and full unit test coverage for the new UI behavior. No documentation changes were made for this small footer addition.

### What changed
- Added a new `Footer` component and integrated it into `App`.
- Footer now includes:
  - Dynamic current-year copyright
  - Centered GitHub logo link to the repo with the required title attribute
  - Action links for `Credits`, `Terms of Use`, and `Privacy Policy`
- Added a reusable `InfoModal` component with accessible dialog behavior:
  - `role="dialog"` and `aria-modal="true"`
  - Close via close button, `Escape` key, and backdrop click
  - Prevent close when clicking inside the modal content
- Updated Credits placeholder copy to include attribution for Pixabay sound effects.
- Added/updated tests to cover all newly introduced behavior.

### Files changed
- `src/App.tsx`
- `src/App.test.tsx`
- `src/components/Footer.tsx`
- `src/components/Footer.test.tsx`
- `src/components/InfoModal.tsx`
- `src/components/InfoModal.test.tsx`

## Related Issues

N/A (no linked issue number)

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] New feature
- [ ] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

## Screenshots (if applicable)

**Footer on large and small screen:**
<img width="837" height="353" alt="Screenshot on 2026-04-22 at 16-06-18" src="https://github.com/user-attachments/assets/356d33d5-c665-4a74-9628-903ac5c0ca3a" />

<img width="1080" height="2340" alt="Screenshot_20260422_160750_Chrome" src="https://github.com/user-attachments/assets/78e20be0-a3c9-466e-aa60-620460155489" />

**Credits modal large and small screen:**
<img width="531" height="191" alt="Screenshot on 2026-04-22 at 16-06-30" src="https://github.com/user-attachments/assets/4a078d4d-6757-4c35-afb7-c4c603ecc743" />

<img width="1080" height="2340" alt="Screenshot_20260422_160956_Chrome" src="https://github.com/user-attachments/assets/953e92d4-c325-49b9-a8e3-f7a37a5825da" />

**Terms of use modal large and small screen:**
<img width="527" height="154" alt="Screenshot on 2026-04-22 at 16-06-45" src="https://github.com/user-attachments/assets/385936f9-3aa0-4359-8e9c-abb548cf4b71" />

<img width="1080" height="2340" alt="Screenshot_20260422_161014_Chrome" src="https://github.com/user-attachments/assets/765d9bcc-4fea-437b-9117-942ee9d760c3" />

**Privacy policy modal large and small screen:**
<img width="522" height="180" alt="Screenshot on 2026-04-22 at 16-07-01" src="https://github.com/user-attachments/assets/d9d1d3a8-ca08-437d-a2cb-d2228120f99c" />

<img width="1080" height="2340" alt="Screenshot_20260422_161026_Chrome" src="https://github.com/user-attachments/assets/b156c3ae-5eb6-4a53-9e1f-2ef1fffacd48" />
