### PR TITLE
Add GitHub Actions workflow config files

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -36,5 +36,5 @@ jobs:
             sleep 1
           done
           curl -fsS http://localhost:5173 > /dev/null
-          npm run a11y
+          npm run a11y:ci
           npm run a11y:faceup

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -29,12 +29,20 @@ jobs:
       - name: Start app and run a11y checks
         run: |
           npm run dev -- --host 0.0.0.0 --port 5173 &
-          for i in {1..60}; do
-            if curl -fsS http://localhost:5173 > /dev/null; then
+          echo "Waiting for Vite at http://localhost:5173/ (up to 60s)…"
+          ready=0
+          for i in $(seq 1 60); do
+            if curl -fsS -o /dev/null --connect-timeout 2 "http://localhost:5173" 2>/dev/null; then
+              ready=1
+              echo "Dev server responded (check $i/60)."
               break
             fi
             sleep 1
           done
-          curl -fsS http://localhost:5173 > /dev/null
+          if [ "$ready" -ne 1 ]; then
+            echo "Error: dev server did not become reachable at http://localhost:5173/ within 60s."
+            curl -v http://localhost:5173/ || true
+            exit 1
+          fi
           npm run a11y:ci
           npm run a11y:faceup

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,40 @@
+name: Accessibility
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  a11y:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chrome for accessibility scans
+        run: npm run a11y:install-chrome
+
+      - name: Start app and run a11y checks
+        run: |
+          npm run dev -- --host 0.0.0.0 --port 5173 &
+          for i in {1..60}; do
+            if curl -fsS http://localhost:5173 > /dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          curl -fsS http://localhost:5173 > /dev/null
+          npm run a11y
+          npm run a11y:faceup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  build:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify production build
+        run: npm run build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,26 @@
+name: Coverage
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  coverage:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run coverage checks
+        run: npm run test:coverage

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,26 @@
+name: Format Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  format:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  lint:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run lint
+        run: npm run lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  test:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit and integration tests
+        run: npm run test

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.9] - 2026-04-24
+
+### Added
+
+- GitHub Actions workflows for open, non-draft pull requests: `tests`, `coverage`, `lint`, `format-check`, `build`, and `a11y` (triggers: `pull_request` with `opened`, `reopened`, `synchronize`, `ready_for_review`; jobs skip draft PRs).
+- `pa11y.ci.json` and npm script `a11y:ci` so Pa11y uses Chrome with `--no-sandbox` in Linux CI (GitHub Actions).
+
+### Changed
+
+- Accessibility workflow runs `npm run a11y:ci` and `npm run a11y:faceup` after starting the Vite dev server, matching local Pa11y usage.
+
 ## [0.0.8] - 2026-04-23
 
 ### Added

--- a/pa11y.ci.json
+++ b/pa11y.ci.json
@@ -1,0 +1,5 @@
+{
+  "chromeLaunchConfig": {
+    "args": ["--no-sandbox"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:coverage": "vitest run --coverage",
     "a11y:install-chrome": "npx puppeteer browsers install chrome",
     "a11y": "pa11y http://localhost:5173",
+    "a11y:ci": "pa11y http://localhost:5173 --config ./pa11y.ci.json",
     "a11y:faceup": "pa11y http://localhost:5173 --config ./pa11y.faceup.json"
   },
   "dependencies": {


### PR DESCRIPTION
# Description

This pull request adds GitHub Actions workflows to enforce CI quality gates on pull requests (non-draft only).  
It introduces separate workflows for tests, coverage, linting, formatting, build verification, and accessibility checks (including the face-up card Pa11y scenario).

## Related Issues

Fixes [#6](https://github.com/allie500/emoji-match-game/issues/6)

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [x] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

_No new unit tests were needed because this change adds CI workflow configuration only. Existing test commands are now enforced in PR checks.  
No documentation update was required since scripts and CI expectations were already documented in `README.md`._

## How to test

1. Confirm these workflow files exist:
   - `.github/workflows/tests.yml`
   - `.github/workflows/coverage.yml`
   - `.github/workflows/lint.yml`
   - `.github/workflows/format-check.yml`
   - `.github/workflows/build.yml`
   - `.github/workflows/a11y.yml`
2. Open a PR from this branch (non-draft).
3. Verify all workflows run in GitHub Actions:
   - Tests (`npm run test`)
   - Coverage (`npm run test:coverage`)
   - Lint (`npm run lint`)
   - Format Check (`npm run format:check`)
   - Build (`npm run build`)
   - Accessibility (`npm run a11y` and `npm run a11y:faceup`)
4. Convert the PR to Draft and confirm jobs are skipped due to the draft gate.
5. Mark PR ready for review again and confirm checks run via `ready_for_review`.

## Screenshots (if applicable)

N/A (no UI changes)