### PR TITLE
Add you won animation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.12] - 2026-04-26
+
+### Added
+
+- Win celebration overlay when the board is cleared: the last matched emoji animates in at the center, “YOU WON” and a “Play Again” control appear. Implemented in `src/components/WinOverlay.tsx` with styles in `src/index.css`.
+- `winningEmoji` on `GameState` so the UI can show the final pair’s emoji; set in `resolveMatch` on the winning match, cleared on new game.
+
+### Changed
+
+- `src/components/Board.tsx` and `src/App.tsx` pass `winningEmoji` and render the overlay instead of the previous inline “You won!” line beside Reset.
+- Extended tests in `src/game/game.test.ts`, `src/components/Board.test.tsx`, and `src/App.test.tsx`, plus new `src/components/WinOverlay.test.tsx`, to cover the feature and keep coverage thresholds green.
+
 ## [0.0.11] - 2026-04-26
 
 ### Changed

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import App from "./App";
 import { playSfx } from "./audio/sfx";
 import { MATCH_DELAY_MS, MISMATCH_DELAY_MS } from "./game/game";
+import { WIN_ZOOM_MS } from "./components/WinOverlay";
 
 const { mockEmojis } = vi.hoisted(() => ({
   mockEmojis: ["🍕", "🍔", "🍟", "🌮", "🌯", "🥑", "🍣", "🍜"],
@@ -22,6 +23,7 @@ vi.mock("./game/game", async (importOriginal) => {
       moves: 0,
       matches: 0,
       numPairs: 8,
+      winningEmoji: null,
       lock: false,
       pendingMismatchIds: null,
       pendingMatchPairKey: null,
@@ -127,5 +129,27 @@ describe("App", () => {
 
     const winCalls = vi.mocked(playSfx).mock.calls.filter(([effect]) => effect === "youWon");
     expect(winCalls).toHaveLength(1);
+  });
+
+  it("shows win overlay content after final match animation and play again resets game", () => {
+    render(<App />);
+
+    const cards = getCardButtons();
+    for (let i = 0; i < mockEmojis.length; i++) {
+      fireEvent.click(cards[i * 2]);
+      fireEvent.click(cards[i * 2 + 1]);
+      act(() => {
+        vi.advanceTimersByTime(MATCH_DELAY_MS);
+      });
+    }
+
+    expect(screen.queryByText("YOU WON")).not.toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(WIN_ZOOM_MS);
+    });
+    expect(screen.getByText("YOU WON")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Play Again" }));
+    expect(screen.getByText(/Matches:/).closest("div")).toHaveTextContent("0/8");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,7 @@ function App() {
         moves={state.moves}
         matches={state.matches}
         numPairs={state.numPairs}
+        winningEmoji={state.winningEmoji}
         onCardClick={onCardClick}
         onReset={onReset}
       />

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Board from "./Board";
 import type { GameCard } from "../game/types";
+import { WIN_ZOOM_MS } from "./WinOverlay";
 
 const sampleCards: GameCard[] = [
   { id: "c1", emoji: "🍕", pairKey: "🍕" },
@@ -22,6 +23,7 @@ describe("Board", () => {
         moves={3}
         matches={1}
         numPairs={2}
+        winningEmoji={null}
         onCardClick={vi.fn()}
         onReset={vi.fn()}
       />,
@@ -43,6 +45,7 @@ describe("Board", () => {
         moves={0}
         matches={0}
         numPairs={2}
+        winningEmoji={null}
         onCardClick={vi.fn()}
         onReset={onReset}
       />,
@@ -51,7 +54,9 @@ describe("Board", () => {
     expect(onReset).toHaveBeenCalledTimes(1);
   });
 
-  it("shows You won! when matches reach numPairs", () => {
+  it("shows the win overlay and lets user play again", async () => {
+    const onReset = vi.fn();
+    vi.useFakeTimers();
     render(
       <Board
         cards={sampleCards}
@@ -62,11 +67,21 @@ describe("Board", () => {
         moves={2}
         matches={2}
         numPairs={2}
+        winningEmoji={"🍔"}
         onCardClick={vi.fn()}
-        onReset={vi.fn()}
+        onReset={onReset}
       />,
     );
-    expect(screen.getByText("You won!")).toBeInTheDocument();
+
+    expect(screen.queryByText("YOU WON")).not.toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(WIN_ZOOM_MS);
+    });
+    expect(screen.getByText("YOU WON")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Play Again" }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 
   it("disables card buttons when lock is true", () => {
@@ -80,6 +95,7 @@ describe("Board", () => {
         moves={0}
         matches={0}
         numPairs={2}
+        winningEmoji={null}
         onCardClick={vi.fn()}
         onReset={vi.fn()}
       />,
@@ -102,6 +118,7 @@ describe("Board", () => {
         moves={0}
         matches={0}
         numPairs={2}
+        winningEmoji={null}
         onCardClick={onCardClick}
         onReset={vi.fn()}
       />,

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,5 +1,6 @@
 import type { CardId, GameCard } from "../game/types";
 import EmojiCard from "./EmojiCard";
+import WinOverlay from "./WinOverlay";
 
 export interface BoardProps {
   cards: GameCard[];
@@ -10,6 +11,7 @@ export interface BoardProps {
   moves: number;
   matches: number;
   numPairs: number;
+  winningEmoji: string | null;
   onCardClick: (cardId: CardId) => void;
   onReset: () => void;
 }
@@ -23,6 +25,7 @@ export default function Board({
   moves,
   matches,
   numPairs,
+  winningEmoji,
   onCardClick,
   onReset,
 }: BoardProps) {
@@ -73,10 +76,10 @@ export default function Board({
         >
           Reset
         </button>
-        {isComplete ? (
-          <p className="text-sm sm:text-base text-emerald-400 font-semibold">You won!</p>
-        ) : null}
       </div>
+      {isComplete && winningEmoji ? (
+        <WinOverlay emoji={winningEmoji} onPlayAgain={onReset} />
+      ) : null}
     </div>
   );
 }

--- a/src/components/WinOverlay.test.tsx
+++ b/src/components/WinOverlay.test.tsx
@@ -1,0 +1,42 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import WinOverlay, { CONFETTI_FADE_START_MS, WIN_ZOOM_MS } from "./WinOverlay";
+
+describe("WinOverlay", () => {
+  it("fades the confetti layer after CONFETTI_FADE_START_MS", () => {
+    vi.useFakeTimers();
+    render(<WinOverlay emoji="🎉" onPlayAgain={vi.fn()} />);
+
+    const confetti = screen.getByTestId("win-confetti");
+    expect(confetti).toHaveClass("opacity-100");
+
+    act(() => {
+      vi.advanceTimersByTime(CONFETTI_FADE_START_MS);
+    });
+    expect(confetti).toHaveClass("opacity-0");
+
+    vi.useRealTimers();
+  });
+
+  it("clears timers on unmount", () => {
+    vi.useFakeTimers();
+    const { unmount } = render(<WinOverlay emoji="🎉" onPlayAgain={vi.fn()} />);
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(CONFETTI_FADE_START_MS);
+    });
+    vi.useRealTimers();
+  });
+
+  it("calls onPlayAgain after the zoom delay", () => {
+    vi.useFakeTimers();
+    const onPlayAgain = vi.fn();
+    render(<WinOverlay emoji="🍕" onPlayAgain={onPlayAgain} />);
+
+    act(() => {
+      vi.advanceTimersByTime(WIN_ZOOM_MS);
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Play Again" }));
+    expect(onPlayAgain).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});

--- a/src/components/WinOverlay.tsx
+++ b/src/components/WinOverlay.tsx
@@ -67,36 +67,41 @@ export default function WinOverlay({ emoji, onPlayAgain }: WinOverlayProps) {
       <section
         role="dialog"
         aria-modal="true"
-        aria-labelledby="win-title"
-        className="relative z-10 flex flex-col items-center gap-4 rounded-2xl border border-white/15 bg-slate-900/80 px-8 py-10 shadow-2xl"
+        aria-labelledby={showContent ? "win-title" : undefined}
+        className="relative z-10 box-border grid w-[min(26rem,90vw)] max-w-full shrink-0 grid-rows-[minmax(4rem,auto)_minmax(0,1fr)_minmax(3.5rem,auto)] gap-3 rounded-2xl border border-white/15 bg-slate-900/80 p-8 aspect-square shadow-2xl sm:gap-4 sm:p-10"
       >
-        {showContent ? (
-          <h2 id="win-title" className="text-3xl sm:text-4xl font-bold tracking-wide text-white">
-            YOU WON
-          </h2>
-        ) : (
-          <div className="h-11" aria-hidden="true" />
-        )}
-
-        <div
-          data-testid="winning-emoji"
-          className="win-emoji-zoom text-7xl sm:text-8xl leading-none"
-          style={{ animationDuration: `${WIN_ZOOM_MS}ms` }}
-        >
-          {emoji}
+        <div className="flex min-h-[4rem] items-end justify-center">
+          {showContent ? (
+            <h2
+              id="win-title"
+              className="text-center text-3xl font-bold tracking-wide text-white sm:text-4xl"
+            >
+              YOU WON
+            </h2>
+          ) : null}
         </div>
 
-        {showContent ? (
-          <button
-            type="button"
-            onClick={onPlayAgain}
-            className="mt-1 px-4 py-2 rounded-lg bg-fuchsia-600 text-white hover:bg-fuchsia-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-500/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+        <div className="flex min-h-0 items-center justify-center">
+          <div
+            data-testid="winning-emoji"
+            className="win-emoji-zoom text-7xl leading-none sm:text-8xl"
+            style={{ animationDuration: `${WIN_ZOOM_MS}ms` }}
           >
-            Play Again
-          </button>
-        ) : (
-          <div className="h-10" aria-hidden="true" />
-        )}
+            {emoji}
+          </div>
+        </div>
+
+        <div className="flex min-h-[3.5rem] items-start justify-center">
+          {showContent ? (
+            <button
+              type="button"
+              onClick={onPlayAgain}
+              className="rounded-lg bg-fuchsia-600 px-4 py-2 text-white hover:bg-fuchsia-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-500/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+            >
+              Play Again
+            </button>
+          ) : null}
+        </div>
       </section>
     </div>
   );

--- a/src/components/WinOverlay.tsx
+++ b/src/components/WinOverlay.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+
+export const WIN_ZOOM_MS = 550;
+export const CONFETTI_FADE_START_MS = 1800;
+export const CONFETTI_FADE_MS = 1200;
+
+interface WinOverlayProps {
+  emoji: string;
+  onPlayAgain: () => void;
+}
+
+export default function WinOverlay({ emoji, onPlayAgain }: WinOverlayProps) {
+  const [showContent, setShowContent] = useState(false);
+  const [fadeConfetti, setFadeConfetti] = useState(false);
+
+  useEffect(() => {
+    const revealContentTimer = window.setTimeout(() => {
+      setShowContent(true);
+    }, WIN_ZOOM_MS);
+    const confettiFadeTimer = window.setTimeout(() => {
+      setFadeConfetti(true);
+    }, CONFETTI_FADE_START_MS);
+
+    return () => {
+      window.clearTimeout(revealContentTimer);
+      window.clearTimeout(confettiFadeTimer);
+    };
+  }, []);
+
+  const confettiPieces = useMemo(
+    () =>
+      Array.from({ length: 20 }, (_, idx) => ({
+        id: idx,
+        left: 4 + idx * 4.7,
+        delay: (idx % 6) * 120,
+        duration: 1800 + (idx % 5) * 220,
+      })),
+    [],
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/55 backdrop-blur-[1px]">
+      <div
+        data-testid="win-confetti"
+        className={[
+          "pointer-events-none absolute inset-0 overflow-hidden transition-opacity",
+          fadeConfetti ? "opacity-0" : "opacity-100",
+        ].join(" ")}
+        style={{ transitionDuration: `${CONFETTI_FADE_MS}ms` }}
+      >
+        {confettiPieces.map((piece) => (
+          <span
+            key={piece.id}
+            className="win-confetti-piece"
+            style={
+              {
+                left: `${piece.left}%`,
+                animationDelay: `${piece.delay}ms`,
+                animationDuration: `${piece.duration}ms`,
+              } as CSSProperties
+            }
+          />
+        ))}
+      </div>
+
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="win-title"
+        className="relative z-10 flex flex-col items-center gap-4 rounded-2xl border border-white/15 bg-slate-900/80 px-8 py-10 shadow-2xl"
+      >
+        {showContent ? (
+          <h2 id="win-title" className="text-3xl sm:text-4xl font-bold tracking-wide text-white">
+            YOU WON
+          </h2>
+        ) : (
+          <div className="h-11" aria-hidden="true" />
+        )}
+
+        <div
+          data-testid="winning-emoji"
+          className="win-emoji-zoom text-7xl sm:text-8xl leading-none"
+          style={{ animationDuration: `${WIN_ZOOM_MS}ms` }}
+        >
+          {emoji}
+        </div>
+
+        {showContent ? (
+          <button
+            type="button"
+            onClick={onPlayAgain}
+            className="mt-1 px-4 py-2 rounded-lg bg-fuchsia-600 text-white hover:bg-fuchsia-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-500/80 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+          >
+            Play Again
+          </button>
+        ) : (
+          <div className="h-10" aria-hidden="true" />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/game/game.test.ts
+++ b/src/game/game.test.ts
@@ -46,6 +46,7 @@ describe("createGame", () => {
     expect(state.moves).toBe(0);
     expect(state.matches).toBe(0);
     expect(state.numPairs).toBe(2);
+    expect(state.winningEmoji).toBeNull();
     expect(state.lock).toBe(false);
     expect(state.pendingMismatchIds).toBeNull();
     expect(state.pendingMatchPairKey).toBeNull();
@@ -66,6 +67,7 @@ function minimalState(overrides: Partial<GameState> = {}): GameState {
     moves: 0,
     matches: 0,
     numPairs: 2,
+    winningEmoji: null,
     lock: false,
     pendingMismatchIds: null,
     pendingMatchPairKey: null,
@@ -159,6 +161,29 @@ describe("gameReducer", () => {
       expect(next.flippedIds).toEqual([]);
       expect(next.lock).toBe(false);
       expect(next.pendingMatchPairKey).toBeNull();
+      expect(next.winningEmoji).toBeNull();
+    });
+
+    it("stores winningEmoji only when final match completes the game", () => {
+      const nonFinal = minimalState({
+        lock: true,
+        flippedIds: ["c1", "c2"],
+        pendingMatchPairKey: "a",
+        matches: 0,
+        numPairs: 2,
+      });
+      const nonFinalNext = gameReducer(nonFinal, { type: "resolveMatch" });
+      expect(nonFinalNext.winningEmoji).toBeNull();
+
+      const finalMatch = minimalState({
+        lock: true,
+        flippedIds: ["c3", "c4"],
+        pendingMatchPairKey: "b",
+        matches: 1,
+        numPairs: 2,
+      });
+      const finalNext = gameReducer(finalMatch, { type: "resolveMatch" });
+      expect(finalNext.winningEmoji).toBe("b");
     });
   });
 

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -58,6 +58,7 @@ export function createGame(config: CreateGameConfig): GameState {
     moves: 0,
     matches: 0,
     numPairs,
+    winningEmoji: null,
     lock: false,
     pendingMismatchIds: null,
     pendingMatchPairKey: null,
@@ -136,6 +137,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
     case "resolveMatch": {
       if (!state.lock || !state.pendingMatchPairKey) return state;
 
+      const nextMatches = state.matches + 1;
+      const isWin = nextMatches >= state.numPairs;
       const nextMatched = new Set(state.matchedPairKeys);
       nextMatched.add(state.pendingMatchPairKey);
 
@@ -143,7 +146,8 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
         ...state,
         flippedIds: [],
         matchedPairKeys: nextMatched,
-        matches: state.matches + 1,
+        matches: nextMatches,
+        winningEmoji: isWin ? state.pendingMatchPairKey : null,
         lock: false,
         pendingMatchPairKey: null,
         pendingMismatchIds: null,

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -17,6 +17,7 @@ export interface GameState {
   moves: number;
   matches: number;
   numPairs: number;
+  winningEmoji: string | null;
 
   /**
    * Prevents user interaction while we wait to flip back a mismatched pair.

--- a/src/index.css
+++ b/src/index.css
@@ -68,9 +68,80 @@
     background: rgb(74 222 128 / 0.1);
   }
 
+  .win-emoji-zoom {
+    animation-name: win-emoji-zoom-in;
+    animation-timing-function: cubic-bezier(0.17, 0.84, 0.44, 1);
+    animation-fill-mode: both;
+  }
+
+  .win-confetti-piece {
+    position: absolute;
+    top: -12vh;
+    width: 0.5rem;
+    height: 0.95rem;
+    border-radius: 0.125rem;
+    background: #a78bfa;
+    opacity: 0.95;
+    animation-name: win-confetti-drop;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+
+  .win-confetti-piece:nth-child(4n + 1) {
+    background: #22d3ee;
+  }
+
+  .win-confetti-piece:nth-child(4n + 2) {
+    background: #a78bfa;
+  }
+
+  .win-confetti-piece:nth-child(4n + 3) {
+    background: #f472b6;
+  }
+
+  .win-confetti-piece:nth-child(4n + 4) {
+    background: #facc15;
+  }
+
+  @keyframes win-emoji-zoom-in {
+    0% {
+      transform: scale(0.1);
+      opacity: 0;
+    }
+    70% {
+      transform: scale(1.08);
+      opacity: 1;
+    }
+    100% {
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes win-confetti-drop {
+    0% {
+      transform: translateY(-10vh) rotate(0deg);
+      opacity: 0;
+    }
+    12% {
+      opacity: 1;
+    }
+    100% {
+      transform: translateY(115vh) rotate(420deg);
+      opacity: 0.8;
+    }
+  }
+
   @media (prefers-color-scheme: dark) {
     .card-front {
       background: rgb(255 255 255 / 0.05);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .win-emoji-zoom,
+    .win-confetti-piece {
+      animation: none !important;
     }
   }
 }


### PR DESCRIPTION
# Description

Adds a full-screen **You won** experience when the last pair is matched, on top of the existing win sound effect:

- **`winningEmoji` on `GameState`** so the UI knows which pair completed the game (set in `resolveMatch` on the final match; cleared on reset).
- **`WinOverlay`**: full-viewport dimmed backdrop, confetti that runs then fades, centered zoom-in for the winning emoji, then “YOU WON” and “Play Again” (same `onReset` as the board’s reset flow). The dialog uses a **fixed square** panel so the dark background does not jump when the title and button appear.
- **Board / App** wire `winningEmoji` and remove the old inline “You won!” line next to Reset.
- **Tests** for reducer behavior, `WinOverlay` (including confetti timer + cleanup), `Board`, and `App` integration; coverage remains at **100%** for configured thresholds.
- **Changelog** updated for **v0.0.12** in `changelog.md`.

## Related Issues

Closes  #19 

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] New feature
- [ ] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

_No documentation update needed on this update. It is a simple game state animation addition._

## How to test

1. Run `npm install` if needed, then `npm test` and `npm run test:coverage` (expect all tests and coverage thresholds to pass).
2. Run `npm run dev` and play until all pairs are matched.
3. Confirm: win SFX still plays; confetti starts with the zoom; **YOU WON** and **Play Again** appear after the zoom; the dark panel size stays stable (no obvious resize jank); **Play Again** starts a new game (matches/moves reset as before).
4. Optional: use **Reset** on the main board when not in the win state to ensure mid-game behavior is unchanged.

## Screenshots (if applicable)

<img width="476" height="481" alt="Screenshot on 2026-04-26 at 16-17-54" src="https://github.com/user-attachments/assets/ba4c88db-a41a-45c9-996e-9d8e2b50acf6" />
