### PR TITLE
Add Husky pre push check

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+
+# Block direct pushes to main.
+while read -r _ _ remote_ref _
+do
+  case "$remote_ref" in
+    refs/heads/main)
+      echo "Error: direct pushes to 'main' are blocked by Husky pre-push."
+      echo "Push to a feature branch and open a pull request instead."
+      exit 1
+      ;;
+  esac
+done
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -70,15 +70,17 @@ Auto-fix formatting:
 npm run format
 ```
 
-## Git Hooks (Pre-commit)
+## Git Hooks
 
-This repo uses `husky` + `lint-staged` for local pre-commit checks.
+This repo uses `husky` + `lint-staged` for local git hook checks.
 
 - On `git commit`, only staged files are checked.
 - Pre-commit runs:
   - ESLint on staged `*.js`, `*.jsx`, `*.ts`, `*.tsx`
   - Prettier write on staged code/config/docs files
 - If a check fails, the commit is blocked until issues are fixed.
+- On `git push`, direct pushes to `main` are blocked by a Husky pre-push guard.
+- Push feature branches and open a pull request for `main` changes.
 
 If hooks are missing locally after install, run:
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.13] - 2026-04-30
+
+### Added
+
+- Added a Husky `.husky/pre-push` hook that blocks direct pushes targeting `main`, including explicit refspec pushes.
+
+### Changed
+
+- Updated `README.md` Git Hooks documentation to include the new pre-push protection workflow.
+
 ## [0.0.12] - 2026-04-26
 
 ### Added


### PR DESCRIPTION
# Description

Adds a new Husky `pre-push` hook that blocks direct pushes to `main` (including explicit refspec pushes) to reduce accidental bypasses of the PR workflow by anyone with branch protection bypass permission.
This keeps existing Husky behavior intact (`pre-commit` still runs `lint-staged`) and updates docs/changelog to reflect the new guard.

## Related Issues

Fixes #25

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Chore: update dependencies or other housekeeping
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

No unit tests were added because this change is a Git hook shell script (`.husky/pre-push`) and was validated with direct hook input simulation.

## How to test

1. Ensure hooks are installed:

```bash
npm install
npm run prepare
```

2. Confirm push to main is blocked:

```
printf "refs/heads/feature/test abc refs/heads/main def\n" | .husky/pre-push
```

Expected:

```
Error message about direct pushes to main being blocked.
Exit code 1.
```

3. Confirm non-main pushes are allowed:

```
printf "refs/heads/feature/test abc refs/heads/feature/ok def\n" | .husky/pre-push
```

Expected:

No error output.
Exit code 0.


4. Verify existing pre-commit behavior remains unchanged:

- Stage a small file change and run git commit.
- Confirm npx lint-staged still executes via .husky/pre-commit.

5. Verify documentation updates:

- README.md includes the pre-push main protection note.
- changelog.md includes the new release entry for this hook change.

## Screenshots (if applicable)

N/A (no UI changes)