### PR TITLE
Update dark theme styles for a11y and add theme toggle

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -44,5 +44,4 @@ jobs:
             curl -v http://localhost:5173/ || true
             exit 1
           fi
-          npm run a11y:ci
-          npm run a11y:faceup
+          npm run a11y:matrix

--- a/README.md
+++ b/README.md
@@ -130,7 +130,26 @@ Run the face-up card scenario (uses `pa11y.faceup.json` to click a card before s
 npm run a11y:faceup
 ```
 
-Recommended workflow: run both commands. The default scan validates the initial load state, and the face-up config scan validates an interacted state while still checking the rest of the page (header, footer, and other non-hidden content).
+Run the full 2x2 matrix (light/dark x base/face-up):
+
+```bash
+npm run a11y:matrix
+```
+
+The matrix command covers:
+
+- Base page in light mode
+- Base page in dark mode
+- Face-up interaction in light mode
+- Face-up interaction in dark mode
+
+If your app is running on a non-default URL, set `PA11Y_URL`:
+
+```bash
+PA11Y_URL=http://localhost:4173 npm run a11y:matrix
+```
+
+Recommended workflow: use `npm run a11y:matrix` for complete local coverage. The individual `a11y` and `a11y:faceup` scripts are still useful for quick, targeted checks.
 
 Tests, build checks, and Pa11y scans are intended to be enforced by GitHub Actions on open PRs, not by local pre-commit hooks.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.14] - 2026-04-30
+
+### Added
+
+- Added persistent light/dark theme support with a new `src/theme.ts` helper (localStorage preference + system fallback) and a new icon-based pill toggle in `src/App.tsx` (sun/moon).
+- Added a parameterized Pa11y matrix runner at `scripts/run-pa11y-matrix.mjs` plus npm script `a11y:matrix` to cover light/dark x base/face-up scenarios.
+
+### Changed
+
+- Updated global theme token behavior in `src/index.css` to support explicit `data-theme` overrides while still honoring `prefers-color-scheme` when no user preference is set.
+- Updated `src/components/Board.tsx` and `src/components/Footer.tsx` to use theme-aware text/border tokens for better dark-mode contrast.
+- Updated `src/App.test.tsx` for theme toggle semantics/persistence coverage and icon-based toggle assertions.
+- Updated accessibility workflow `.github/workflows/a11y.yml` to run `npm run a11y:matrix`, and refreshed `README.md` Accessibility docs with matrix usage and `PA11Y_URL` override guidance.
+
 ## [0.0.13] - 2026-04-30
 
 ### Added

--- a/pa11y.ci.json
+++ b/pa11y.ci.json
@@ -1,5 +1,7 @@
 {
   "chromeLaunchConfig": {
     "args": ["--no-sandbox"]
-  }
+  },
+  "timeout": 30000,
+  "wait": 500
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "a11y:install-chrome": "npx puppeteer browsers install chrome",
     "a11y": "pa11y http://localhost:5173",
     "a11y:ci": "pa11y http://localhost:5173 --config ./pa11y.ci.json",
-    "a11y:faceup": "pa11y http://localhost:5173 --config ./pa11y.faceup.json"
+    "a11y:faceup": "pa11y http://localhost:5173 --config ./pa11y.faceup.json",
+    "a11y:matrix": "node ./scripts/run-pa11y-matrix.mjs"
   },
   "dependencies": {
     "react": "^19.2.4",

--- a/scripts/run-pa11y-matrix.mjs
+++ b/scripts/run-pa11y-matrix.mjs
@@ -1,0 +1,45 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const targetUrl = process.env.PA11Y_URL ?? "http://localhost:5173";
+
+const runs = [
+  { scenario: "base", mode: "light", configPath: "pa11y.ci.json" },
+  { scenario: "base", mode: "dark", configPath: "pa11y.ci.json" },
+  { scenario: "faceup", mode: "light", configPath: "pa11y.faceup.json" },
+  { scenario: "faceup", mode: "dark", configPath: "pa11y.faceup.json" },
+];
+
+const modeFlag = {
+  light: "--force-light-mode",
+  dark: "--force-dark-mode",
+};
+
+for (const run of runs) {
+  const raw = readFileSync(run.configPath, "utf8");
+  const config = JSON.parse(raw);
+  const args = new Set(config.chromeLaunchConfig?.args ?? []);
+  args.add("--no-sandbox");
+  args.add(modeFlag[run.mode]);
+
+  const merged = {
+    ...config,
+    chromeLaunchConfig: {
+      ...config.chromeLaunchConfig,
+      args: [...args],
+    },
+  };
+
+  const tempDir = mkdtempSync(join(tmpdir(), "pa11y-matrix-"));
+  const tempConfigPath = join(tempDir, `${run.scenario}-${run.mode}.json`);
+  writeFileSync(tempConfigPath, JSON.stringify(merged, null, 2));
+
+  try {
+    process.stdout.write(`\nRunning Pa11y: ${run.scenario} + ${run.mode}\n`);
+    execFileSync("npx", ["pa11y", targetUrl, "--config", tempConfigPath], { stdio: "inherit" });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -41,6 +41,20 @@ function getCardButtons() {
 
 describe("App", () => {
   beforeEach(() => {
+    window.localStorage.clear();
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(prefers-color-scheme: dark)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
     vi.useFakeTimers();
     vi.mocked(playSfx).mockClear();
   });
@@ -53,6 +67,33 @@ describe("App", () => {
     render(<App />);
     expect(screen.getByRole("heading", { name: "🤔 Emoji Match 🎉" })).toBeInTheDocument();
     expect(screen.getByText(/Flip two cards to find matching emojis/)).toBeInTheDocument();
+  });
+
+  it("uses system dark theme by default and toggles to light mode", () => {
+    render(<App />);
+
+    const themeToggle = screen.getByRole("button", { name: "Toggle dark mode" });
+    expect(themeToggle).toHaveAttribute("aria-pressed", "true");
+    expect(themeToggle).toHaveTextContent("Dark");
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(window.localStorage.getItem("emoji-match-theme")).toBe("dark");
+
+    fireEvent.click(themeToggle);
+
+    expect(themeToggle).toHaveAttribute("aria-pressed", "false");
+    expect(themeToggle).toHaveTextContent("Light");
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(window.localStorage.getItem("emoji-match-theme")).toBe("light");
+  });
+
+  it("restores saved theme preference from localStorage", () => {
+    window.localStorage.setItem("emoji-match-theme", "light");
+    render(<App />);
+
+    const themeToggle = screen.getByRole("button", { name: "Toggle dark mode" });
+    expect(themeToggle).toHaveAttribute("aria-pressed", "false");
+    expect(themeToggle).toHaveTextContent("Light");
+    expect(document.documentElement.dataset.theme).toBe("light");
   });
 
   it("renders footer content with legal links", () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -72,16 +72,17 @@ describe("App", () => {
   it("uses system dark theme by default and toggles to light mode", () => {
     render(<App />);
 
-    const themeToggle = screen.getByRole("button", { name: "Toggle dark mode" });
+    const themeToggle = screen.getByRole("button", { name: "Switch to light mode" });
     expect(themeToggle).toHaveAttribute("aria-pressed", "true");
-    expect(themeToggle).toHaveTextContent("Dark");
+    expect(themeToggle).toHaveTextContent("☾");
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(window.localStorage.getItem("emoji-match-theme")).toBe("dark");
 
     fireEvent.click(themeToggle);
 
     expect(themeToggle).toHaveAttribute("aria-pressed", "false");
-    expect(themeToggle).toHaveTextContent("Light");
+    expect(themeToggle).toHaveAccessibleName("Switch to dark mode");
+    expect(themeToggle).toHaveTextContent("☀");
     expect(document.documentElement.dataset.theme).toBe("light");
     expect(window.localStorage.getItem("emoji-match-theme")).toBe("light");
   });
@@ -90,9 +91,9 @@ describe("App", () => {
     window.localStorage.setItem("emoji-match-theme", "light");
     render(<App />);
 
-    const themeToggle = screen.getByRole("button", { name: "Toggle dark mode" });
+    const themeToggle = screen.getByRole("button", { name: "Switch to dark mode" });
     expect(themeToggle).toHaveAttribute("aria-pressed", "false");
-    expect(themeToggle).toHaveTextContent("Light");
+    expect(themeToggle).toHaveTextContent("☀");
     expect(document.documentElement.dataset.theme).toBe("light");
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,25 @@
-import { useEffect, useReducer, useRef } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { playSfx } from "./audio/sfx";
 import Board from "./components/Board";
 import Footer from "./components/Footer";
 import { createGame, gameReducer, MATCH_DELAY_MS, MISMATCH_DELAY_MS } from "./game/game";
 import type { CardId } from "./game/types";
+import { applyTheme, persistTheme, resolveInitialTheme, type Theme } from "./theme";
 
 const NUM_PAIRS = 8;
 const COLS = 4;
 
 function App() {
+  const [theme, setTheme] = useState<Theme>(() => resolveInitialTheme());
   const [state, dispatch] = useReducer(gameReducer, undefined, () =>
     createGame({ numPairs: NUM_PAIRS }),
   );
   const hasPlayedWinSfxRef = useRef(false);
+
+  useEffect(() => {
+    applyTheme(theme);
+    persistTheme(theme);
+  }, [theme]);
 
   useEffect(() => {
     if (!state.lock) return;
@@ -51,11 +58,27 @@ function App() {
     dispatch({ type: "reset", next: createGame({ numPairs: NUM_PAIRS }) });
   };
 
+  const onThemeToggle = () => {
+    setTheme((current) => (current === "dark" ? "light" : "dark"));
+  };
+  const isDarkTheme = theme === "dark";
+
   return (
     <div className="min-h-[100svh] flex flex-col items-center justify-center px-4 py-8">
       <header className="w-full max-w-2xl text-center mb-6">
-        <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight">🤔 Emoji Match 🎉</h1>
-        <p className="mt-2 text-sm sm:text-base text-slate-500">
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight">🤔 Emoji Match 🎉</h1>
+          <button
+            type="button"
+            aria-label="Toggle dark mode"
+            aria-pressed={isDarkTheme}
+            onClick={onThemeToggle}
+            className="rounded-lg border border-[var(--border)] bg-[var(--code-bg)] px-3 py-1.5 text-sm font-medium text-[var(--text-h)] transition-colors hover:bg-[var(--social-bg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-500"
+          >
+            {isDarkTheme ? "Dark" : "Light"}
+          </button>
+        </div>
+        <p className="mt-2 text-sm sm:text-base text-[var(--text-muted)]">
           Flip two cards to find matching emojis.
         </p>
       </header>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ function App() {
     setTheme((current) => (current === "dark" ? "light" : "dark"));
   };
   const isDarkTheme = theme === "dark";
+  const nextThemeLabel = isDarkTheme ? "light mode" : "dark mode";
 
   return (
     <div className="min-h-[100svh] flex flex-col items-center justify-center px-4 py-8">
@@ -73,12 +74,22 @@ function App() {
           </h1>
           <button
             type="button"
-            aria-label="Toggle dark mode"
+            aria-label={`Switch to ${nextThemeLabel}`}
             aria-pressed={isDarkTheme}
             onClick={onThemeToggle}
-            className="justify-self-end rounded-lg border border-[var(--border)] bg-[var(--code-bg)] px-3 py-1.5 text-sm font-medium text-[var(--text-h)] transition-colors hover:bg-[var(--social-bg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-500"
+            className="justify-self-end inline-flex h-8 w-16 items-center rounded-full border border-[var(--border)] bg-[var(--code-bg)] px-1 transition-colors hover:bg-[var(--social-bg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-500"
           >
-            {isDarkTheme ? "Dark" : "Light"}
+            <span className="sr-only">
+              {isDarkTheme ? "Dark mode enabled" : "Light mode enabled"}
+            </span>
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-full bg-[var(--bg)] text-[var(--text-h)] shadow-sm transition-transform ${
+                isDarkTheme ? "translate-x-8" : "translate-x-0"
+              }`}
+              aria-hidden="true"
+            >
+              {isDarkTheme ? "☾" : "☀"}
+            </span>
           </button>
         </div>
         <p className="mt-2 text-sm sm:text-base text-[var(--text-muted)]">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,14 +66,17 @@ function App() {
   return (
     <div className="min-h-[100svh] flex flex-col items-center justify-center px-4 py-8">
       <header className="w-full max-w-2xl text-center mb-6">
-        <div className="flex items-center justify-between gap-4">
-          <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight">🤔 Emoji Match 🎉</h1>
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-4">
+          <span aria-hidden="true" />
+          <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight justify-self-center">
+            🤔 Emoji Match 🎉
+          </h1>
           <button
             type="button"
             aria-label="Toggle dark mode"
             aria-pressed={isDarkTheme}
             onClick={onThemeToggle}
-            className="rounded-lg border border-[var(--border)] bg-[var(--code-bg)] px-3 py-1.5 text-sm font-medium text-[var(--text-h)] transition-colors hover:bg-[var(--social-bg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-500"
+            className="justify-self-end rounded-lg border border-[var(--border)] bg-[var(--code-bg)] px-3 py-1.5 text-sm font-medium text-[var(--text-h)] transition-colors hover:bg-[var(--social-bg)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-500"
           >
             {isDarkTheme ? "Dark" : "Light"}
           </button>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -34,12 +34,12 @@ export default function Board({
   return (
     <div className="w-full max-w-2xl flex flex-col items-center gap-4">
       <div className="w-full flex items-center justify-between px-2">
-        <div className="text-sm sm:text-base text-slate-500">
-          Moves: <span className="text-slate-600 font-semibold">{moves}</span>
+        <div className="text-sm sm:text-base text-[var(--text-muted)]">
+          Moves: <span className="text-[var(--text-muted-strong)] font-semibold">{moves}</span>
         </div>
-        <div className="text-sm sm:text-base text-slate-500">
+        <div className="text-sm sm:text-base text-[var(--text-muted)]">
           Matches:{" "}
-          <span className="text-slate-600 font-semibold">
+          <span className="text-[var(--text-muted-strong)] font-semibold">
             {matches}/{numPairs}
           </span>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,8 +26,8 @@ export default function Footer() {
 
   return (
     <>
-      <footer className="mt-8 w-full max-w-2xl border-t border-slate-700 pt-4">
-        <div className="grid gap-3 text-center text-sm text-slate-500 sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+      <footer className="mt-8 w-full max-w-2xl border-t border-[var(--border)] pt-4">
+        <div className="grid gap-3 text-center text-sm text-[var(--text-muted)] sm:grid-cols-[1fr_auto_1fr] sm:items-center">
           <p className="sm:text-left">Copyright {year} Emoji Match Game.</p>
           <a
             href={GITHUB_REPO_URL}
@@ -35,7 +35,7 @@ export default function Footer() {
             rel="noreferrer"
             title="This project is open source. View the code on Github."
             aria-label="View source on Github"
-            className="mx-auto rounded-md p-1 text-slate-300 hover:bg-slate-800 hover:text-white"
+            className="mx-auto rounded-md p-1 text-[var(--text-muted)] hover:bg-[var(--social-bg)] hover:text-[var(--text-h)]"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -49,21 +49,21 @@ export default function Footer() {
           <div className="flex items-center justify-center gap-3 sm:justify-end">
             <button
               type="button"
-              className="text-slate-500 hover:text-slate-700"
+              className="text-[var(--text-muted)] hover:text-[var(--text-muted-strong)]"
               onClick={() => setActiveModal("credits")}
             >
               Credits
             </button>
             <button
               type="button"
-              className="text-slate-500 hover:text-slate-700"
+              className="text-[var(--text-muted)] hover:text-[var(--text-muted-strong)]"
               onClick={() => setActiveModal("terms")}
             >
               Terms of Use
             </button>
             <button
               type="button"
-              className="text-slate-500 hover:text-slate-700"
+              className="text-[var(--text-muted)] hover:text-[var(--text-muted-strong)]"
               onClick={() => setActiveModal("privacy")}
             >
               Privacy Policy

--- a/src/index.css
+++ b/src/index.css
@@ -149,6 +149,8 @@
 :root {
   --text: #6b6375;
   --text-h: #08060d;
+  --text-muted: #64748b;
+  --text-muted-strong: #475569;
   --bg: #fff;
   --border: #e5e4e7;
   --code-bg: #f4f3ec;
@@ -164,7 +166,7 @@
 
   font: 18px/145% var(--sans);
   letter-spacing: 0.18px;
-  color-scheme: light dark;
+  color-scheme: light;
   color: var(--text);
   background: var(--bg);
   font-synthesis: none;
@@ -177,10 +179,28 @@
   }
 }
 
+:root[data-theme="dark"] {
+  --text: #9ca3af;
+  --text-h: #f3f4f6;
+  --text-muted: #cbd5e1;
+  --text-muted-strong: #e2e8f0;
+  --bg: #16171d;
+  --border: #2e303a;
+  --code-bg: #1f2028;
+  --accent: #c084fc;
+  --accent-bg: rgba(192, 132, 252, 0.15);
+  --accent-border: rgba(192, 132, 252, 0.5);
+  --social-bg: rgba(47, 48, 58, 0.5);
+  --shadow: rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
+  color-scheme: dark;
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --text: #9ca3af;
     --text-h: #f3f4f6;
+    --text-muted: #cbd5e1;
+    --text-muted-strong: #e2e8f0;
     --bg: #16171d;
     --border: #2e303a;
     --code-bg: #1f2028;
@@ -189,6 +209,7 @@
     --accent-border: rgba(192, 132, 252, 0.5);
     --social-bg: rgba(47, 48, 58, 0.5);
     --shadow: rgba(0, 0, 0, 0.4) 0 10px 15px -3px, rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
+    color-scheme: dark;
   }
 
   #social .button-icon {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
+import { applyTheme, resolveInitialTheme } from "./theme";
+
+applyTheme(resolveInitialTheme());
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,40 @@
+export type Theme = "light" | "dark";
+
+const THEME_STORAGE_KEY = "emoji-match-theme";
+
+function isTheme(value: unknown): value is Theme {
+  return value === "light" || value === "dark";
+}
+
+export function getStoredTheme(): Theme | null {
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return isTheme(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getSystemTheme(): Theme {
+  if (window.matchMedia?.("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  }
+
+  return "light";
+}
+
+export function resolveInitialTheme(): Theme {
+  return getStoredTheme() ?? getSystemTheme();
+}
+
+export function applyTheme(theme: Theme) {
+  document.documentElement.dataset.theme = theme;
+}
+
+export function persistTheme(theme: Theme) {
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch {
+    // Ignore write failures (private mode/storage restrictions).
+  }
+}


### PR DESCRIPTION
# Description

This pull request implements the accessibility and theming work for issue #20 by introducing a user-selectable light/dark mode toggle, improving dark-theme contrast, and expanding accessibility validation coverage.

### Highlights

- Added persistent theme support with system fallback:
  - New `src/theme.ts` helper to resolve/apply/persist theme preference (`localStorage` + `prefers-color-scheme` fallback).
  - Theme applied at startup in `src/main.tsx` to avoid initial mismatch.
- Added a new pill-style theme toggle in `src/App.tsx`:
  - Icon-based UI (sun for light, crescent moon for dark).
  - Accessible semantics (`aria-label`, `aria-pressed`, screen-reader text).
- Improved theme contrast behavior:
  - Refined CSS token strategy in `src/index.css` using explicit `:root[data-theme="dark"]` plus system fallback when no explicit selection is set.
  - Replaced hardcoded low-contrast text colors in `src/App.tsx`, `src/components/Board.tsx`, and `src/components/Footer.tsx` with theme-aware variables.
- Expanded automated accessibility coverage:
  - Added `scripts/run-pa11y-matrix.mjs` and npm script `a11y:matrix` to run a 2x2 matrix:
    - base + light
    - base + dark
    - faceup + light
    - faceup + dark
  - Updated `.github/workflows/a11y.yml` to run `npm run a11y:matrix`.
  - Kept existing Pa11y config files as shared scenario configs and parameterized theme mode at runtime.
- Updated docs and changelog:
  - Added matrix testing instructions and `PA11Y_URL` override examples to `README.md`.
  - Added release notes in `changelog.md` (`0.0.14`).

## Related Issues

Fixes #20 

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [x] New feature
- [ ] Chore: update dependencies or other housekeeping
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

## How to test

1. Install dependencies:

```bash
npm ci
```

2. Run unit tests:

```
npm test
```

3. Install Chrome for Pa11y (if needed):
```
npm run a11y:install-chrome
```

4. Run full accessibility matrix:

```
npm run a11y:matrix
```

5. Manual UI verification:

- Confirm header title remains centered.
- Toggle theme using the pill switch (sun/moon icons).
- Refresh page and verify theme preference persists.
- Verify readability/contrast of subtitle, board stats, footer links, and modal triggers in both themes.

## Screenshots (if applicable)

<img width="843" height="416" alt="Screenshot on 2026-04-30 at 16-49-36" src="https://github.com/user-attachments/assets/6948f0a2-4ba5-4fd7-952e-efcb7e0f6ada" />

<img width="828" height="394" alt="Screenshot on 2026-04-30 at 16-49-51" src="https://github.com/user-attachments/assets/984f11d4-3a2e-4f4b-a670-ff9bf45fe377" />

<img width="823" height="393" alt="Screenshot on 2026-04-30 at 16-50-06" src="https://github.com/user-attachments/assets/e6a3ce3f-a375-43f1-8b88-a61fdebd170f" />

<img width="831" height="378" alt="Screenshot on 2026-04-30 at 16-50-16" src="https://github.com/user-attachments/assets/39d15519-78bc-4f8f-b055-6ac75eb7ac21" />
