### PR TITLE
Fix Chrome setup

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -23,8 +23,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Chrome for accessibility scans
-        run: npm run a11y:install-chrome
+      - name: Setup Chrome for accessibility scans
+        run: |
+          CHROME="$(command -v google-chrome-stable)"
+          if [ -z "$CHROME" ]; then
+            echo "Error: google-chrome-stable not found on runner"
+            exit 1
+          fi
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME" >> "$GITHUB_ENV"
+          echo "Using Chrome at: $CHROME"
 
       - name: Start app and run a11y checks
         run: |


### PR DESCRIPTION
# Description

Fixes the failing **Install Chrome for accessibility scans** step in the Accessibility GitHub Actions workflow.

The workflow previously ran `npm run a11y:install-chrome`, which downloads Chrome via Puppeteer. On `ubuntu-latest` with Node.js 24.16+, a known regression in `extract-zip` (used by `@puppeteer/browsers`) can partially extract the Chrome zip, leaving a cache folder without the `chrome` executable. Subsequent installs then fail with:

> The browser folder exists but the executable is missing

This change skips the Puppeteer download in CI and points Pa11y/Puppeteer at the runner's pre-installed `google-chrome-stable` via `PUPPETEER_EXECUTABLE_PATH`. Local development is unchanged; developers can still use `npm run a11y:install-chrome` as documented in the README.

## Related Issues

Fixes #33

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [ ] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

**Notes on checklist items:**

- **Changelog:** Intentionally not updated — this is a CI-only workflow fix and does not affect the application.
- **Unit tests:** Not added. The change is limited to the GitHub Actions workflow; behavior is validated by the Accessibility workflow itself on PRs.
- **Documentation:** Not updated. The README already documents `npm run a11y:install-chrome` for local use, which remains the correct local workflow.

## How to test

1. Open or update a non-draft pull request with this branch.
2. Confirm the **Accessibility** workflow completes successfully.
3. Verify the **Setup Chrome for accessibility scans** step logs the system Chrome path (e.g. `/usr/bin/google-chrome-stable`).
4. Confirm the **Start app and run a11y checks** step runs `npm run a11y:matrix` without Chrome install errors.

Optional local sanity check (unchanged from before):

1. Run `npm run a11y:install-chrome`, then `npm run dev` and `npm run a11y:matrix` in separate terminals.

## Screenshots (if applicable)

N/A — CI workflow change only.
