### PR TITLE
Add Github issue templates and config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report something that isn't working correctly
+title: ""
+labels: ""
+assignees: ""
+---
+
+<!-- markdownlint-disable MD001 MD025 -->
+
+# Description
+
+<!-- What went wrong? -->
+
+### Steps to reproduce
+
+<!-- Numbered steps to trigger the bug. -->
+
+### Log output
+
+<!-- Paste console errors, test failures, or other relevant logs. -->
+
+### Acceptance criteria
+
+<!-- What does "fixed" look like? -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,21 @@
+---
+name: General Issue
+about: Propose a feature, enhancement, or task
+title: ""
+labels: ""
+assignees: ""
+---
+
+<!-- markdownlint-disable MD001 MD025 -->
+
+# Description
+
+<!-- What should be done and why? -->
+
+### Acceptance criteria
+
+<!-- List concrete, testable outcomes. -->
+
+### Developer context
+
+<!-- Relevant files, constraints, or implementation notes for whoever picks this up. -->


### PR DESCRIPTION
# Description

Adds GitHub issue templates to streamline issue creation, as specified in #37. Contributors can choose between a **General Issue** template and a **Bug Report** template from the "New issue" picker. Both templates use `# Description` as the first heading (H1) and `###` for all remaining sections (H3).

## Related Issues

Fixes #37

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [x] New feature
- [ ] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request, or explained why no changelog entry is needed.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

**Notes on checklist items:**

- **Changelog:** Not updated — this is repository infrastructure only and does not affect the application.
- **Tests:** Not applicable — issue templates are markdown/YAML files with no runtime behavior to unit test.
- **Documentation:** Not updated — the README project structure section was intentionally left unchanged per the issue scope.

## How to test

1. Merge this PR (or push the branch and use the GitHub UI on the feature branch if templates are visible before merge).
2. Open **Issues → New issue** on the repository.
3. Confirm the template chooser shows **General Issue** and **Bug Report**.
4. Select **General Issue** and verify the body includes:
   - `# Description` (H1)
   - `### Acceptance criteria` (H3)
   - `### Developer context` (H3)
5. Select **Bug Report** and verify the body includes:
   - `# Description` (H1)
   - `### Steps to reproduce` (H3)
   - `### Log output` (H3)
   - `### Acceptance criteria` (H3)
6. Confirm that creating a blank issue is disabled (`blank_issues_enabled: false` in `config.yml`).

## Files added

| File | Purpose |
|------|---------|
| `.github/ISSUE_TEMPLATE/general.md` | General issue template (Description, Acceptance criteria, Developer context) |
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug report template (Description, Steps to reproduce, Log output, Acceptance criteria) |
| `.github/ISSUE_TEMPLATE/config.yml` | Template chooser config; blank issues disabled |

## Screenshots (if applicable)

N/A — GitHub UI verification after merge is sufficient.
