### PR TITLE
Add main element landmark for accessibility 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.17] - 2026-06-22
+
+### Changed
+
+- Updated `index.html` to mount the React app on `<main id="root">` instead of a generic `<div>`, adding a document-level main landmark for screen reader navigation (issue #38).
+
 ## [0.0.16] - 2026-05-25
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <title>Emoji Match Game</title>
   </head>
   <body>
-    <div id="root"></div>
+    <main id="root"></main>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
# Description

Replaces the React mount element in `index.html` from `<div id="root">` to `<main id="root">`, adding a document-level main landmark for screen reader navigation.

Lighthouse reported: *"Document does not have a main landmark."* The app already uses `<header>` and `<footer>` inside the React tree, but those do not satisfy the document-level landmark check on their own. Using `<main>` as the mount element is the minimal fix scoped to `index.html`, as specified in the issue acceptance criteria. No React code changes are required — `src/main.tsx` continues to mount via `getElementById("root")`.

## Related Issues

Fixes #38

## Type of Change

- [x] Bug fix
- [ ] Enhancement
- [ ] New feature
- [ ] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

**Tests:** No new unit tests were added. Existing tests render `<App />` directly and do not load `index.html`. The change is a one-line HTML semantic update with no application logic impact; existing tests, lint, format, and build checks confirm nothing regressed.

**Documentation:** No README or other documentation updates are needed. The change is recorded in `changelog.md` under `[0.0.17] - 2026-06-22`.

## How to test

1. Check out this branch and run `npm install` if needed.
2. Run the standard project checks:
   - `npm test`
   - `npm run lint`
   - `npm run format:check`
   - `npm run build`
3. Start the dev server with `npm run dev`.
4. Open the app in Chrome and run a Lighthouse Accessibility audit (DevTools → Lighthouse). Confirm *"Document does not have a main landmark"* is no longer reported.
5. Optionally run `npm run a11y:matrix` (requires Chrome for Testing) to match CI accessibility coverage.

## Screenshots (if applicable)

N/A — no visible UI changes.
