### PR TITLE
Add completed moves to WinOverlay component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.18] - 2026-06-22
+
+### Added
+
+- Win overlay now shows total moves to complete the game (`Completed in x moves.`) after the winning emoji zoom animation (issue #41).
+
 ## [0.0.17] - 2026-06-22
 
 ### Changed

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -78,6 +78,7 @@ describe("Board", () => {
       vi.advanceTimersByTime(WIN_ZOOM_MS);
     });
     expect(screen.getByText("YOU WON")).toBeInTheDocument();
+    expect(screen.getByText("Completed in 2 moves.")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Play Again" }));
     expect(onReset).toHaveBeenCalledTimes(1);

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -78,7 +78,7 @@ export default function Board({
         </button>
       </div>
       {isComplete && winningEmoji ? (
-        <WinOverlay emoji={winningEmoji} onPlayAgain={onReset} />
+        <WinOverlay emoji={winningEmoji} moves={moves} onPlayAgain={onReset} />
       ) : null}
     </div>
   );

--- a/src/components/WinOverlay.test.tsx
+++ b/src/components/WinOverlay.test.tsx
@@ -4,7 +4,7 @@ import WinOverlay, { CONFETTI_FADE_START_MS, WIN_ZOOM_MS } from "./WinOverlay";
 describe("WinOverlay", () => {
   it("fades the confetti layer after CONFETTI_FADE_START_MS", () => {
     vi.useFakeTimers();
-    render(<WinOverlay emoji="🎉" onPlayAgain={vi.fn()} />);
+    render(<WinOverlay emoji="🎉" moves={0} onPlayAgain={vi.fn()} />);
 
     const confetti = screen.getByTestId("win-confetti");
     expect(confetti).toHaveClass("opacity-100");
@@ -19,7 +19,7 @@ describe("WinOverlay", () => {
 
   it("clears timers on unmount", () => {
     vi.useFakeTimers();
-    const { unmount } = render(<WinOverlay emoji="🎉" onPlayAgain={vi.fn()} />);
+    const { unmount } = render(<WinOverlay emoji="🎉" moves={0} onPlayAgain={vi.fn()} />);
     unmount();
     act(() => {
       vi.advanceTimersByTime(CONFETTI_FADE_START_MS);
@@ -30,13 +30,30 @@ describe("WinOverlay", () => {
   it("calls onPlayAgain after the zoom delay", () => {
     vi.useFakeTimers();
     const onPlayAgain = vi.fn();
-    render(<WinOverlay emoji="🍕" onPlayAgain={onPlayAgain} />);
+    render(<WinOverlay emoji="🍕" moves={0} onPlayAgain={onPlayAgain} />);
 
     act(() => {
       vi.advanceTimersByTime(WIN_ZOOM_MS);
     });
     fireEvent.click(screen.getByRole("button", { name: "Play Again" }));
     expect(onPlayAgain).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("shows move count after the zoom delay", () => {
+    vi.useFakeTimers();
+    render(<WinOverlay emoji="🎉" moves={7} onPlayAgain={vi.fn()} />);
+
+    const moveCount = screen.getByText("Completed in 7 moves.");
+    expect(moveCount).toHaveClass("invisible", "opacity-0");
+    expect(moveCount).toHaveAttribute("aria-hidden", "true");
+
+    act(() => {
+      vi.advanceTimersByTime(WIN_ZOOM_MS);
+    });
+    expect(moveCount).toHaveClass("visible", "opacity-100");
+    expect(moveCount).toHaveAttribute("aria-hidden", "false");
+
     vi.useRealTimers();
   });
 });

--- a/src/components/WinOverlay.tsx
+++ b/src/components/WinOverlay.tsx
@@ -7,10 +7,11 @@ export const CONFETTI_FADE_MS = 1200;
 
 interface WinOverlayProps {
   emoji: string;
+  moves: number;
   onPlayAgain: () => void;
 }
 
-export default function WinOverlay({ emoji, onPlayAgain }: WinOverlayProps) {
+export default function WinOverlay({ emoji, moves, onPlayAgain }: WinOverlayProps) {
   const [showContent, setShowContent] = useState(false);
   const [fadeConfetti, setFadeConfetti] = useState(false);
 
@@ -81,7 +82,7 @@ export default function WinOverlay({ emoji, onPlayAgain }: WinOverlayProps) {
           ) : null}
         </div>
 
-        <div className="flex min-h-0 items-center justify-center">
+        <div className="flex min-h-0 flex-col items-center justify-center gap-2">
           <div
             data-testid="winning-emoji"
             className="win-emoji-zoom text-7xl leading-none sm:text-8xl"
@@ -89,6 +90,15 @@ export default function WinOverlay({ emoji, onPlayAgain }: WinOverlayProps) {
           >
             {emoji}
           </div>
+          <p
+            className={[
+              "text-center text-lg leading-7 text-slate-300 transition-opacity duration-200 sm:text-xl",
+              showContent ? "visible opacity-100" : "invisible opacity-0",
+            ].join(" ")}
+            aria-hidden={!showContent}
+          >
+            Completed in {moves} moves.
+          </p>
         </div>
 
         <div className="flex min-h-[3.5rem] items-start justify-center">


### PR DESCRIPTION
# Description

Adds a move count to the window overlay so players can see how many turns it took to complete the game. After the winning emoji zoom animation finishes, the overlay displays **"Completed in x moves."** below the emoji, using the existing `state.moves` value from game state (no reducer changes required).

The moves text is always rendered in the layout but hidden until the zoom completes (`invisible opacity-0` → `visible opacity-100`), which reserves space up front and prevents the emoji from jumping when the text appears.

## Related Issues

Fixes #41

## Type of Change

- [ ] Bug fix
- [x] Enhancement
- [ ] New feature
- [ ] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

No separate documentation updates are needed beyond the changelog entry.

## How to test

1. Run the unit tests:

   ```bash
   npm test -- src/components/WinOverlay.test.tsx src/components/Board.test.tsx
   ```

2. Start the dev server (`npm run dev`) and play through a full game.
3. On the final match, confirm the win overlay appears with the zooming emoji.
4. After the zoom animation (~550ms), confirm **"Completed in x moves."** fades in below the emoji and matches the move count shown in the board header.
5. Confirm the emoji does not resize or shift vertically when the moves text appears.
6. Click **Play Again** and verify the board resets as before.

## Screenshots (if applicable)

<!-- Add a screenshot or screen recording of the win overlay showing the move count after the zoom animation. -->

**Before change:**

<img width="477" height="475" alt="winoverlay-no-moves" src="https://github.com/user-attachments/assets/9d10a7a9-9b84-4bd1-97c0-55a101b7fa83" />

**After change:**

<img width="476" height="475" alt="winoverlay-moves" src="https://github.com/user-attachments/assets/4eaf7c9f-2306-4267-98c8-e14df7476ccb" />