### PR TITLE
Bump js-yaml dependency

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.21] - 2026-07-28
+
+### Changed
+
+- Bumped transitive dependency `js-yaml` from `4.2.0` to `4.3.0` (via pa11y → puppeteer → cosmiconfig) to address GHSA-52cp-r559-cp3m. Issue #47.
+
 ## [0.0.20] - 2026-07-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emoji-match-game",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emoji-match-game",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "dependencies": {
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -3764,9 +3764,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emoji-match-game",
   "private": true,
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
# Description

Bumps the transitive `js-yaml` dependency from `4.2.0` to `4.3.0` to address [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (CVE-2026-59869).

`pa11y` is already at the latest release (`^9.1.1`), so Dependabot could not open an update PR without proposing an invalid downgrade. The vulnerable package is pulled in via `pa11y` → `puppeteer` → `cosmiconfig`, and `cosmiconfig` already allows `js-yaml@^4.1.0`, so a lockfile bump to `4.3.0` is sufficient. Package version is `0.0.21`.

## Related Issues

Fixes #47

## Type of Change

- [ ] Bug fix
- [ ] Enhancement
- [ ] New feature
- [x] Chore: update dependencies or other housekeeping
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have updated the changelog.md file to include the changes in this pull request.
- [x] I have written unit tests to cover the changes in this pull request, or explained why no tests are needed in the pull request description.
- [x] I have made corresponding changes to the documentation, or explained why no documentation is needed in the pull request description.

No new unit tests or app docs are needed: this is a transitive dependency lockfile bump with no application or Pa11y config changes. Existing automated tests and the a11y CI workflow cover regression risk.

## How to test

1. Run `npm ci`.
2. Confirm the patched version is installed:
   ```bash
   npm ls js-yaml
   ```
   Expected path: `pa11y` → `puppeteer` → `cosmiconfig` → `js-yaml@4.3.0`.
3. Confirm the advisory is cleared:
   ```bash
   npm audit
   ```
   `js-yaml` / GHSA-52cp-r559-cp3m should no longer appear.
4. Run `npm test` and `npm run build`.
5. Optionally smoke accessibility locally (`npm run a11y:matrix` with the app running), or rely on the Accessibility workflow on this PR.

## Screenshots (if applicable)

N/A — dependency-only change; no UI updates.
